### PR TITLE
Updated inputs to match common scheme

### DIFF
--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -11,9 +11,9 @@
 #' or otherwise variance-stabilized), where rows are genes and columns are cells.
 #' Alternatively, a \linkS4class{SummarizedExperiment} object containing such a matrix.
 #' @param ref.id Integer scalar specifying the reference cell/sample to use.
-#' @param assay.type.sc Integer scalar or string specifying the assay of \code{test} containing the relevant expression data.  
+#' @param test.assay.type Integer scalar or string specifying the assay of \code{test} containing the relevant expression data.  
 #' Used if \code{test} is a \linkS4class{SummarizedExperiment}.
-#' @param assay.type.train Integer scalar or string specifying the assay of \code{ref} containing the relevant expression data.  
+#' @param ref.assay.type Integer scalar or string specifying the assay of \code{ref} containing the relevant expression data.  
 #' Used if provided \code{ref} is a \linkS4class{SummarizedExperiment}.
 #'
 #' @return A \link{ggplot} object containing a scatter plot of the cell against a reference.
@@ -44,12 +44,12 @@
 #' @importFrom SummarizedExperiment assay
 #' @importClassesFrom SummarizedExperiment SummarizedExperiment
 #' @importFrom methods is
-plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.sc = 'logcounts', assay.type.train = 'logcounts') {
+plotCellVsReference <- function(test, test.id, ref, ref.id, test.assay.type = 'logcounts', ref.assay.type = 'logcounts') {
     if (is(test, "SummarizedExperiment")) {
-        test <- assay(test, assay.type.sc)
+        test <- assay(test, test.assay.type)
     }
     if (is(ref, "SummarizedExperiment")) {
-        ref <- assay(ref, assay.type.train)
+        ref <- assay(ref, ref.assay.type)
     }
 
     rownames(test) <- tolower(rownames(test))


### PR DESCRIPTION
updated the assay.type inputs in plotCellVsReference to match the rest of the naming scheme:
 - assay.type.sc -> test.assay.type
 - assay.type.train -> ref.assay.type